### PR TITLE
imageWithRgbaWidget: add Size method

### DIFF
--- a/Widgets.go
+++ b/Widgets.go
@@ -696,6 +696,11 @@ func ImageWithRgba(rgba *image.RGBA) *ImageWithRgbaWidget {
 	}
 }
 
+func (i *ImageWithRgbaWidget) Size(width, height float32) *ImageWithRgbaWidget {
+	i.width, i.height = width, height
+	return i
+}
+
 func (i *ImageWithRgbaWidget) Build() {
 	state := Context.GetState(i.id)
 


### PR DESCRIPTION
doing ImageWithRgba(...).Size(...) caused unexpected behavior: image wasn't displayed.
it was because `Size` refers to embeded `ImageWidget` (not `ImageWithRgbaWidget) and the ImageWidget.Size returns ImageWidget. calling `Build` caused building ImageWidget (embeded into imagewithrgba)